### PR TITLE
add Aqua quality checks to test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ComplexRegions"
 uuid = "c64915e2-6c82-11e9-38e9-1f159a780463"
-authors = ["Toby Driscoll <driscoll@udel.edu>"]
 version = "0.3.9"
+authors = ["Toby Driscoll <driscoll@udel.edu>"]
 
 [deps]
 CircularArrays = "7a955b69-7140-5f4e-a0ed-f168c5e2e749"
@@ -24,14 +24,15 @@ ComplexRegionsPlotsExt = "Plots"
 ComplexRegionsPythonCallExt = "PythonCall"
 
 [compat]
+Aqua = "0.8"
 CircularArrays = "1"
 ComplexValues = "0.3"
 Dierckx = "0.5"
 ForwardDiff = "1"
-PythonCall = "0.9"
 LinearAlgebra = "1"
 Makie = "0.24"
 Plots = "1"
+PythonCall = "0.9"
 Reexport = "1"
 StaticArrays = "1"
 Statistics = "1"
@@ -39,8 +40,9 @@ Test = "1"
 julia = "1"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Statistics"]
+test = ["Test", "Statistics", "Aqua"]

--- a/src/curves.jl
+++ b/src/curves.jl
@@ -192,7 +192,7 @@ ClosedCurve(f::Function, df::Function=t -> ForwardDiff.derivative(f,t); kw...) =
 ClosedCurve(f::Function, a::Real, b::Real; kw...) = ClosedCurve(Curve(f, a, b; kw...))
 ClosedCurve(f::Function, df::Function, a::Real, b::Real; kw...) = ClosedCurve(Curve(f, df, a, b; kw...))
 
-ClosedCurve(c::Curve{T}, args...) where T = ClosedCurve{T}(c, args...)
+ClosedCurve(c::Curve{T}; kw...) where T = ClosedCurve{T}(c; kw...)
 function ClosedCurve(f::Function, args...)
 	c = Curve(f, args...)
 	return ClosedCurve{real_type(c)}(c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,12 @@ check(u::Number, v::Number, T::Type=real_type(float(u))) = isapprox(u, v, rtol=5
 check(u::AbstractArray, v::AbstractArray) = all(check(u, v) for (u, v) in zip(u, v))
 check(u::AbstractArray, v::Number) = all(check(u, v) for u in u)
 using Test
+using Aqua
+
+@testset "Aqua quality assurance" begin
+    Aqua.test_all(ComplexRegions)
+end
+
 @testset "Utilities" begin
     @test CR.scaleto(1im, 3im, [0.5, 0.75]) ≈ [2.0im, 2.5im]
     @test CR.scalefrom(1im, 3im, [2im, 1im, 1.5im]) ≈ [0.5, 0, 0.25]


### PR DESCRIPTION
Add Aqua.jl as a test-only dependency and run Aqua.test_all in the suite. Fix a genuine method ambiguity it surfaced: ClosedCurve(c::Curve, args...) collided with the (f::Function, ...) constructors because Curve <: Function. The varargs target took no extra positional args, so narrow it to a single-curve method with keyword forwarding.