### PR TITLE
add JET static analysis to test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ CircularArrays = "1"
 ComplexValues = "0.3"
 Dierckx = "0.5"
 ForwardDiff = "1"
+JET = "0.9, 0.10"
 LinearAlgebra = "1"
 Makie = "0.24"
 Plots = "1"
@@ -41,8 +42,9 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Statistics", "Aqua"]
+test = ["Test", "Statistics", "Aqua", "JET"]

--- a/src/discretize.jl
+++ b/src/discretize.jl
@@ -9,6 +9,7 @@ end
 
 function refine_discretization(p::AbstractCurveOrPath, lims::AbstractVector, ds::Real)
     t = collect(range(lims[1], lims[2], 20))
+    z = p.(t)
     idx = [1]
     while length(idx) > 0
         z = p.(t)
@@ -205,7 +206,7 @@ function discretize(E::ExteriorRegion, n::Integer=600)
     r *= 4//3
     xlims = mean(xlims) .+ (-r, r)
     ylims = mean(ylims) .+ (-r, r)
-    return discretize(ConnectedRegion(nothing, E.inner), n, limits=(xlims..., ylims...))
+    return invoke(discretize, Tuple{AbstractConnectedRegion,Any}, E, n; limits=(xlims..., ylims...))
 end
 
 # Utility function for the main calls.

--- a/src/polygons.jl
+++ b/src/polygons.jl
@@ -335,7 +335,7 @@ inv(r::Rectangle) = inv(Polygon(r))
 # these provide shortcuts
 Base.:+(r::Rectangle, z::Number) = Rectangle(r.center + z, r.radii, r.rotation)
 Base.:+(z::Number, r::Rectangle) = r + z
-Base.:-(r::Rectangle) = rectangle(-verices(r))
+Base.:-(r::Rectangle) = rectangle(-vertices(r))
 Base.:-(r::Rectangle, z::Number) = Rectangle(r.center - z, r.radii, r.rotation)
 Base.:-(z::Number, r::Rectangle) = (-r) + z
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,9 +5,21 @@ check(u::AbstractArray, v::AbstractArray) = all(check(u, v) for (u, v) in zip(u,
 check(u::AbstractArray, v::Number) = all(check(u, v) for u in u)
 using Test
 using Aqua
+using JET
 
 @testset "Aqua quality assurance" begin
     Aqua.test_all(ComplexRegions)
+end
+
+@testset "JET static analysis" begin
+    # Informational only: run JET's static analysis and report findings without
+    # failing the suite. Inference-limitation false positives (which work via
+    # runtime dispatch) can appear depending on the Julia version, so this is a
+    # non-blocking heads-up rather than a hard gate.
+    rep = report_package(ComplexRegions; target_modules=(ComplexRegions,))
+    n = length(JET.get_reports(rep))
+    n > 0 && @warn "JET reported $n possible issue(s) (informational; see output above)."
+    @test true
 end
 
 @testset "Utilities" begin


### PR DESCRIPTION
Add JET as a test-only dependency and run report_package in an informational (non-blocking) testset, so JET surfaces regressions without failing CI on inference-limitation false positives.

Fix three genuine latent bugs JET caught in untested code paths:
- Rectangle negation called `verices` (typo for `vertices`).
- discretize(::ExteriorRegion) referenced a nonexistent `ConnectedRegion`; dispatch to the generic AbstractConnectedRegion method via invoke (ExteriorRegion already has outerboundary == nothing).
- refine_discretization used `z` after its while loop without binding it outside the loop body.